### PR TITLE
Update relations between `PlayerProfile` and `GameSession`

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,7 +21,7 @@ model User {
   imageUrl String?
 
   playerProfiles PlayerProfile[]
-  collections CardCollection[]
+  collections    CardCollection[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -36,14 +36,12 @@ model PlayerProfile {
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId String @db.ObjectId
 
-  sessions   GameSession[] @relation(fields: [sessionIds], references: [id])
-  sessionIds String[]      @db.ObjectId
-
-  startedSessions GameSession[] @relation("SessionOwner")
+  sessions      GameSession[] @relation("SessionOwner")
+  guestSessions GameSession[] @relation("SessionGuest")
 
   results Result[]
   /// [PlayerStats]
-  stats Json @default("{ \"score\": 0, \"timer\": 0, \"flips\": 0, \"matches\": 0, \"sessions\": 0 }")
+  stats   Json     @default("{ \"score\": 0, \"timer\": 0, \"flips\": 0, \"matches\": 0, \"sessions\": 0 }")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -63,18 +61,18 @@ model GameSession {
   stats Json
 
   /// [SessionCard]
-  cards        Json[]
+  cards   Json[]
   /// [SessionCardMetadata]
   flipped Json[]
 
-  collection CardCollection? @relation(fields: [collectionId], references: [id], onDelete: SetNull)
-  collectionId String? @db.ObjectId
+  collection   CardCollection? @relation(fields: [collectionId], references: [id], onDelete: SetNull)
+  collectionId String?         @db.ObjectId
 
-  owner   PlayerProfile @relation("SessionOwner", fields: [ownerId], references: [id])
-  ownerId String        @db.ObjectId
+  owner   PlayerProfile? @relation("SessionOwner", fields: [ownerId], references: [id], onDelete: SetNull)
+  ownerId String?        @db.ObjectId
 
-  players   PlayerProfile[] @relation(fields: [playerIds], references: [id])
-  playerIds String[]        @db.ObjectId
+  guest   PlayerProfile? @relation("SessionGuest", fields: [guestId], references: [id], onDelete: SetNull)
+  guestId String?        @db.ObjectId
 
   results Result[]
 
@@ -95,7 +93,7 @@ model Result {
   player   PlayerProfile @relation(fields: [playerId], references: [id], onDelete: Cascade)
   playerId String        @db.ObjectId
 
-  session   GameSession @relation(fields: [sessionId], references: [id])
+  session   GameSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
   sessionId String      @db.ObjectId
 
   createdAt DateTime @default(now())
@@ -103,23 +101,23 @@ model Result {
 }
 
 model MemoryCard {
-  id String @id @default(auto()) @map("_id") @db.ObjectId
+  id    String @id @default(auto()) @map("_id") @db.ObjectId
   utKey String @unique
 
   imageUrl String
 
-  collection CardCollection @relation(fields: [collectionId], references: [id], onDelete: Cascade)
-  collectionId String @db.ObjectId
+  collection   CardCollection @relation(fields: [collectionId], references: [id], onDelete: Cascade)
+  collectionId String         @db.ObjectId
 }
 
 model CardCollection {
   id String @id @default(auto()) @map("_id") @db.ObjectId
 
-  name String
+  name        String
   description String
-  tableSize TableSize
+  tableSize   TableSize
 
-  cards MemoryCard[]
+  cards    MemoryCard[]
   sessions GameSession[]
 
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/src/components/session/session-count.tsx
+++ b/src/components/session/session-count.tsx
@@ -9,9 +9,9 @@ import { trpc } from "@/server/trpc/client"
 // hooks
 import { useFilterStore } from "@/hooks/store/use-filter-store"
 
-const SessionCount = () => {
+const SessionCount = ({ playerId }: { playerId: string }) => {
   const filter = useFilterStore<SessionFilter>((state) => state.history)
-  const [sessionCount] = trpc.session.count.useSuspenseQuery(filter)
+  const [sessionCount] = trpc.session.count.useSuspenseQuery({ playerId, ...filter })
 
   return (
     <>

--- a/src/components/session/session-counter.tsx
+++ b/src/components/session/session-counter.tsx
@@ -15,7 +15,7 @@ import { Separator } from "@/components/ui/separator"
 import { SessionCount } from "@/components/session"
 
 const SessionCounter = ({ player }: { player: ClientPlayer }) => {
-  void trpc.session.count.prefetch({})
+  void trpc.session.count.prefetch({ playerId: player.id })
 
   return (
     <div className="mt-5 pt-3 flex gap-x-2 border-t border-border/50">
@@ -30,7 +30,7 @@ const SessionCounter = ({ player }: { player: ClientPlayer }) => {
 
         <HydrateClient>
           <Suspense fallback={<Loader2 className="size-3.5 shrink-0 text-muted-foreground animate-spin" strokeWidth={4} />}>
-            <SessionCount />
+            <SessionCount playerId={player.id} />
           </Suspense>
         </HydrateClient>
       </div>

--- a/src/config/player-settings.ts
+++ b/src/config/player-settings.ts
@@ -15,3 +15,21 @@ export const offlinePlayerMetadata = {
     sessions: 0
   }
 } satisfies ClientPlayer
+
+/* Deleted player placeholder */
+export const deletedPlayerPlaceholder = {
+  color: '#ffffff',
+  id: '_deleted',
+  tag: 'Deleted player',
+  isActive: false,
+  imageUrl: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  stats: {
+    score: 0,
+    timer: 0,
+    flips: 0,
+    matches: 0,
+    sessions: 0
+  }
+} satisfies ClientPlayer

--- a/src/config/session-settings.ts
+++ b/src/config/session-settings.ts
@@ -10,18 +10,24 @@ export const offlineSessionMetadata = {
 } satisfies Omit<ClientGameSession, keyof UnsignedClientGameSession>
 
 export const sessionSchemaFields = {
-  owner: true,
-  collection: {
-    include: {
-      user: true,
-      cards: true
-    }
-  },
-  players: {
+  owner: {
     include: {
       user: {
         select: { imageUrl: true }
       }
+    }
+  },
+  guest: {
+    include: {
+      user: {
+        select: { imageUrl: true }
+      }
+    }
+  },
+  collection: {
+    include: {
+      user: true,
+      cards: true
     }
   }
 } satisfies Prisma.GameSessionInclude

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -91,7 +91,7 @@ declare global {
   /* Session types */
   declare type ClientGameSession = Omit<
     GameSession,
-    'id' | 'collectionId' | 'ownerId' | 'playerIds' | 'cards' |
+    'id' | 'collectionId' | 'ownerId' | 'guestId' | 'cards' |
     'continuedAt' | 'closedAt' | 'updatedAt'
   > & {
     players: {
@@ -128,7 +128,8 @@ declare global {
   /* Prisma schemas */
   declare type GameSessionWithPlayersWithAvatarWithCollectionWithCards = GameSession & {
     collection: CardCollectionWithCardsWithUser | null
-    players: PlayerProfileWithUserAvatar[]
+    owner?: PlayerProfileWithUserAvatar | null
+    guest?: PlayerProfileWithUserAvatar | null
   }
 
   declare type CardCollectionWithCards = CardCollection & {

--- a/src/lib/util/parser/session-parser.ts
+++ b/src/lib/util/parser/session-parser.ts
@@ -7,7 +7,7 @@ import { sessionFilterSchema } from "@/lib/schema/param/session-param"
 
 // config
 import { getFallbackCollection } from "@/config/collection-settings"
-import { offlinePlayerMetadata } from "@/config/player-settings"
+import { deletedPlayerPlaceholder } from "@/config/player-settings"
 
 // helpers
 import { pairSessionCardsWithCollection } from "@/lib/helper/session-helper"
@@ -58,7 +58,7 @@ export function parseSchemaToClientSession(
   if (session.mode === 'SINGLE') {
     currentClientPlayer = session.owner
       ? parseSchemaToClientPlayer(session.owner)
-      : offlinePlayerMetadata
+      : deletedPlayerPlaceholder
   } else {
     const currentPlayer = session.owner?.id === currentPlayerId
       ? session.owner
@@ -68,8 +68,8 @@ export function parseSchemaToClientSession(
       ? session.owner
       : session.guest
 
-    currentClientPlayer = currentPlayer ? parseSchemaToClientPlayer(currentPlayer) : offlinePlayerMetadata
-    otherClientPlayer = otherPlayer ? parseSchemaToClientPlayer(otherPlayer) : offlinePlayerMetadata
+    currentClientPlayer = currentPlayer ? parseSchemaToClientPlayer(currentPlayer) : deletedPlayerPlaceholder
+    otherClientPlayer = otherPlayer ? parseSchemaToClientPlayer(otherPlayer) : deletedPlayerPlaceholder
   }
 
   return {

--- a/src/lib/util/parser/session-parser.ts
+++ b/src/lib/util/parser/session-parser.ts
@@ -45,7 +45,7 @@ export const offlineSessionKeys: (keyof UnsignedClientGameSession)[] = [
  */
 export function parseSchemaToClientSession(
   session: GameSessionWithPlayersWithAvatarWithCollectionWithCards,
-  currentPlayerId: string | null | undefined
+  currentPlayerId: string = deletedPlayerPlaceholder.id
 ): ClientGameSession {
   const parserKeys = clientSessionKeys.filter((key) => key !== 'players')
   const filteredSession = pickFields(session, parserKeys)

--- a/src/lib/util/parser/session-parser.ts
+++ b/src/lib/util/parser/session-parser.ts
@@ -7,6 +7,7 @@ import { sessionFilterSchema } from "@/lib/schema/param/session-param"
 
 // config
 import { getFallbackCollection } from "@/config/collection-settings"
+import { offlinePlayerMetadata } from "@/config/player-settings"
 
 // helpers
 import { pairSessionCardsWithCollection } from "@/lib/helper/session-helper"
@@ -18,17 +19,15 @@ import { pickFields } from "@/lib/util/parser"
 /* Schema parser keys */
 export const clientSessionKeys: (keyof ClientGameSession)[] = [
   'slug', 'collectionId',
+  'players',
   'type', 'mode', 'tableSize', 'status',
-  'players', 'stats',
-  'flipped', 'cards',
-  'startedAt', 'continuedAt', 'closedAt', 'updatedAt'
+  'stats', 'flipped', 'cards',
+  'startedAt', 'continuedAt', 'closedAt'
 ] as const
 
 export const offlineSessionKeys: (keyof UnsignedClientGameSession)[] = [
-  'collectionId',
-  'tableSize',
-  'players', 'stats',
-  'flipped', 'cards',
+  'collectionId', 'players', 'tableSize',
+  'stats', 'flipped', 'cards',
   'startedAt', 'continuedAt'
 ] as const
 
@@ -46,25 +45,41 @@ export const offlineSessionKeys: (keyof UnsignedClientGameSession)[] = [
  */
 export function parseSchemaToClientSession(
   session: GameSessionWithPlayersWithAvatarWithCollectionWithCards,
-  currentPlayerId: string
+  currentPlayerId: string | null | undefined
 ): ClientGameSession {
-  const filteredSession = pickFields(session, clientSessionKeys)
-
-  const players = {
-    current: filteredSession.players.find((player) => player.id === currentPlayerId)!,
-    other: filteredSession.players.find((player) => player.id !== currentPlayerId)
-  }
+  const parserKeys = clientSessionKeys.filter((key) => key !== 'players')
+  const filteredSession = pickFields(session, parserKeys)
 
   const sessionCollection = session.collection ?? getFallbackCollection(session.tableSize)
+
+  let currentClientPlayer: ClientPlayer
+  let otherClientPlayer: ClientPlayer | null | undefined
+
+  if (session.mode === 'SINGLE') {
+    currentClientPlayer = session.owner
+      ? parseSchemaToClientPlayer(session.owner)
+      : offlinePlayerMetadata
+  } else {
+    const currentPlayer = session.owner?.id === currentPlayerId
+      ? session.owner
+      : session.guest
+    
+    const otherPlayer = session.guest?.id === currentPlayerId
+      ? session.owner
+      : session.guest
+
+    currentClientPlayer = currentPlayer ? parseSchemaToClientPlayer(currentPlayer) : offlinePlayerMetadata
+    otherClientPlayer = otherPlayer ? parseSchemaToClientPlayer(otherPlayer) : offlinePlayerMetadata
+  }
 
   return {
     ...filteredSession,
     collectionId: sessionCollection.id,
-    cards: pairSessionCardsWithCollection(session.cards, sessionCollection.cards),
     players: {
-      current: parseSchemaToClientPlayer(players.current),
-      other: players.other ? parseSchemaToClientPlayer(players.other) : null
-    }
+      current: currentClientPlayer,
+      other: otherClientPlayer
+    },
+    cards: pairSessionCardsWithCollection(session.cards, sessionCollection.cards)
   }
 }
 
@@ -86,18 +101,23 @@ export function parseSessionFilter(
   userId: string,
   filterInput: z.infer<typeof sessionFilterSchema>
 ): Prisma.GameSessionWhereInput {
-  const where: Prisma.GameSessionWhereInput = { owner: { userId } }
+  const where: Prisma.GameSessionWhereInput = {
+    OR: [
+      { owner: { userId } },
+      { guest: { userId } }
+    ]
+  }
 
   const { success, data: filter } = sessionFilterSchema.safeParse(filterInput)
   if (!success) return where
 
-  return {
-    ...where,
-    ...filter,
-    players: {
-      some: {
-        id: { equals: filter.playerId }
-      }
-    }
+  if (filter.playerId) {
+    where.OR = [
+      { ownerId: filter.playerId },
+      { guestId: filter.playerId }
+    ]
+    delete filter.playerId
   }
+
+  return { ...where, ...filter }
 }

--- a/src/server/action/index.ts
+++ b/src/server/action/index.ts
@@ -96,11 +96,10 @@ export const sessionActionClient = playerActionClient.use(async ({ ctx, next }) 
   const activeSession = await ctx.db.gameSession.findFirst({
     where: {
       status: 'RUNNING',
-      players: {
-        some: {
-          id: ctx.player.id
-        }
-      }
+      OR: [
+        { ownerId: ctx.player.id },
+        { guestId: ctx.player.id }
+      ]
     },
     include: sessionSchemaFields
   })
@@ -110,15 +109,6 @@ export const sessionActionClient = playerActionClient.use(async ({ ctx, next }) 
       key: 'SESSION_NOT_FOUND',
       message: 'Game session not found.',
       description: "You are currently not participating in any game session."
-    })
-  }
-
-  const hasAccess = activeSession.players.some((player) => player.userId === ctx.user.id)
-  if (!hasAccess) {
-    ApiError.throw({
-      key: 'SESSION_ACCESS_DENIED',
-      message: "Game session access denied.",
-      description: "You don't have access to this game session."
     })
   }
 

--- a/src/server/action/session-action.ts
+++ b/src/server/action/session-action.ts
@@ -59,9 +59,10 @@ export const createSession = playerActionClient
     const activeSession = await ctx.db.gameSession.findFirst({
       where: {
         status: 'RUNNING',
-        players: {
-          some: { id: ctx.player.id }
-        }
+        OR: [
+          { ownerId: ctx.player.id },
+          { guestId: ctx.player.id }
+        ]
       }
     })
 
@@ -128,8 +129,8 @@ export const createSession = playerActionClient
         owner: {
           connect: { id: ctx.player.id }
         },
-        players: { // TODO: connect guest (update validation schema)
-          connect: [{ id: ctx.player.id }]
+        guest: { // TODO: connect guest (update validation schema)
+          // connect: { id: sessionValues.guestId }
         }
       }
     })
@@ -277,9 +278,6 @@ export const saveOfflineSession = protectedActionClient
           connect: { id: collectionId }
         },
         owner: {
-          connect: { id: playerId }
-        },
-        players: {
           connect: { id: playerId }
         }
       }

--- a/src/server/trpc/router/player-router.ts
+++ b/src/server/trpc/router/player-router.ts
@@ -34,12 +34,10 @@ export const playerProfileRouter = createTRPCRouter({
       const sessions = await ctx.db.gameSession.findMany({
         where: {
           ...sessionFilter,
-          players: {
-            some: {
-              userId: ctx.user.id,
-              ...playerFilter
-            }
-          }
+          OR: [
+            { owner: { userId: ctx.user.id, ...playerFilter } },
+            { guest: { userId: ctx.user.id, ...playerFilter } }
+          ]
         },
         select: {
           stats: true,


### PR DESCRIPTION
The biggest change is in the prisma schema. All the other stuff are just updated parsers and prisma db queries.

- Removed `players` field from the `GameSession` model.
- Added `guest (PlayerProfile)` field to the `GameSession` model *`(1-n)`* and using the already existing `owner` field to access session users.

These changes make the db model simpler and easier to work with at all.

> *These changes had to be made in preparation for multiplayer game modes.*